### PR TITLE
Change mholt references to caddyserver (#2751)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,15 +54,15 @@ Contributing to Go projects on GitHub is fun and easy. We recommend the followin
 
 1. [Fork this repo](https://github.com/caddyserver/caddy). This makes a copy of the code you can write to.
 
-2. If you don't already have this repo (mholt/caddy.git) repo on your computer, get it with `go get github.com/caddyserver/caddy/caddy`.
+2. If you don't already have this repo (caddyserver/caddy.git) repo on your computer, get it with `go get github.com/caddyserver/caddy/caddy`.
 
-3. Tell git that it can push the mholt/caddy.git repo to your fork by adding a remote: `git remote add myfork https://github.com/you/caddy.git`
+3. Tell git that it can push the caddyserver/caddy.git repo to your fork by adding a remote: `git remote add myfork https://github.com/you/caddy.git`
 
-4. Make your changes in the mholt/caddy.git repo on your computer.
+4. Make your changes in the caddyserver/caddy.git repo on your computer.
 
 5. Push your changes to your fork: `git push myfork`
 
-6. [Create a pull request](https://github.com/caddyserver/caddy/pull/new/master) to merge your changes into mholt/caddy @ master. (Click "compare across forks" and change the head fork.)
+6. [Create a pull request](https://github.com/caddyserver/caddy/pull/new/master) to merge your changes into caddyserver/caddy @ master. (Click "compare across forks" and change the head fork.)
 
 This workflow is nice because you don't have to change import paths. You can get fancier by using different branches if you want.
 


### PR DESCRIPTION
mholt/caddy.git references are changed to caddyserver/caddy.git in the link titles

---
name: Pull request
about: Propose changes to the code
title: ''
labels: ''
assignees: ''
---

<!--
Thank you for contributing to Caddy! Please fill this out to help us make the most of your pull request.

Was this change discussed in an issue first? That can help save time in case the change is not a good fit for the project. Not all pull requests get merged.

It is not uncommon for pull requests to go through several, iterative reviews. Please be patient with us! Every reviewer is a volunteer, and each has their own style.
-->

## 1. What does this change do, exactly?
<!-- Please be specific. Motivate the problem, and justify why this is the best solution. -->




## 2. Please link to the relevant issues.
<!-- This adds crucial context to your change. -->




## 3. Which documentation changes (if any) need to be made because of this PR?
<!-- Reviewers will often reference this first in order to know what to expect from the change. Please be specific enough so that they can paste your wording into the documentation directly. -->




## 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
- [ ] I am willing to help maintain this change if there are issues with it later
